### PR TITLE
Implement creatable select

### DIFF
--- a/src/components/Connection/ConnectionForm.tsx
+++ b/src/components/Connection/ConnectionForm.tsx
@@ -9,6 +9,7 @@ import {
 import { Formik, FormikProps } from 'formik'
 import { Fragment, useContext, useEffect, useState } from 'react'
 import { IConnection, UpdateConnectionInput } from 'types/Connection'
+import { JWTSession, Theme } from 'types/JWTSession'
 import {
   OAuthError,
   SessionExpiredModalContext,
@@ -21,7 +22,6 @@ import ArrowLeftIcon from 'mdi-react/ArrowLeftIcon'
 import CheckIcon from 'mdi-react/CheckIcon'
 import { ConnectionBadge } from 'components/Connections'
 import { IOptionType } from 'components/Inputs/SearchSelect'
-import { JWTSession, Theme } from 'types/JWTSession'
 import Link from 'next/link'
 import ReactMarkdown from 'react-markdown'
 import client from 'lib/axios'
@@ -276,6 +276,8 @@ const ConnectionForm = ({ connection, token, jwt }: IProps) => {
                               disabled={disabled}
                               options={options as IOptionType[]}
                               placeholder={disabled ? 'Available after authorization' : 'Select..'}
+                              // TODO: Replace true with allow_custom_fields (when implemented)
+                              isCreatable={false}
                             />
                           )}
                           {description && (

--- a/src/components/Inputs/FilteredSelect.tsx
+++ b/src/components/Inputs/FilteredSelect.tsx
@@ -19,7 +19,7 @@ const FilteredSelect = ({ field, formikProps, className = '' }: IProps) => {
 
   const filterValue: unknown = values[filterOn]
   const filterOptions = filterValue
-    ? (options as FormFieldOptionGroup[]).find((optionGroup: FormFieldOptionGroup) => {
+    ? (options as FormFieldOptionGroup[])?.find((optionGroup: FormFieldOptionGroup) => {
         return optionGroup.id === filterValue
       })?.options
     : []

--- a/src/components/Inputs/SearchSelect.tsx
+++ b/src/components/Inputs/SearchSelect.tsx
@@ -117,7 +117,7 @@ const SearchSelect = ({
       ? options?.filter((option: IOptionType) => value?.includes(option.value))
       : options?.find((option: IOptionType) => option.value === value)
 
-    if (isCreatable && value) {
+    if (isCreatable) {
       option = rest.isMulti ? [{ label: value, value }] : { label: value, value }
     }
 


### PR DESCRIPTION
The `SearchSelect` component now takes an `isCreatable` prop which determines if a new value can be added in the select field. That's now set to `true` in the `ConnectionForm`, but should be replaced with `allow_custom_fields` as soon as that is available. 

Also discussed during standup and in more detail with @elsmr that this should be a temporary implementation and we should add a new endpoint to get the form fields (something like `GET /connections/{id}` or `GET /connections/{id}/form_fields`) so we can use pagination to get all the results and we also don't have to fetch all that data in the overview page. Elias will create/has created an issue for that. 