### PR TITLE
F/connector grid view

### DIFF
--- a/src/components/Connection/ConnectionForm.tsx
+++ b/src/components/Connection/ConnectionForm.tsx
@@ -136,13 +136,13 @@ const ConnectionForm = ({ connection, token, jwt }: IProps) => {
         headers
       })
       mutate('/vault/connections')
-      router.push('/')
       addToast({
         title: `Integration successfully deleted`,
         description: 'You can re-add it anytime you want.',
         type: 'success',
         autoClose: true
       })
+      router.push('/')
     } catch (error) {
       setDeleteError(true)
       if (error?.response?.status === 401) {

--- a/src/components/Connection/ConnectionsGrid.tsx
+++ b/src/components/Connection/ConnectionsGrid.tsx
@@ -1,0 +1,31 @@
+import GridCard from 'components/Connection/GridCard'
+import { IConnection } from 'types/Connection'
+
+interface Props {
+  connections: IConnection[]
+  handleClick: (connection: IConnection, i: number) => void
+  isLoading: boolean | string
+  cursor: boolean | number
+}
+
+const ConnectionsGrid = ({ connections, isLoading, handleClick, cursor }: Props) => {
+  return (
+    <div className="grid grid-cols-2 gap-4 mt-8 mb-8 text-center md:grid-cols-3 lg:grid-cols-3 md:gap-6 lg:gap-4 xl:gap-6">
+      {connections?.map((connection: IConnection, i: number) => {
+        const delay = Math.max(0, i * 30)
+        return (
+          <GridCard
+            connection={connection}
+            delay={delay}
+            key={i}
+            handleClick={() => handleClick(connection, i)}
+            isLoading={isLoading === connection.id}
+            isActive={cursor === i}
+          />
+        )
+      })}
+    </div>
+  )
+}
+
+export default ConnectionsGrid

--- a/src/components/Connection/GridCard.tsx
+++ b/src/components/Connection/GridCard.tsx
@@ -16,7 +16,7 @@ const GridCard = ({ connection, handleClick, isLoading, isActive = false }: IPro
   return (
     <div
       className={classNames(
-        'mx-auto cursor-pointer relative w-full px-4 hover:bg-gray-50 pt-6 pb-4 font-medium shadow-sm hover:shadow-md border border-gray-200 rounded-md transition duration-150 ease-in-out text-gray-700 hover:text-gray-900',
+        'mx-auto cursor-pointer relative w-full px-3 sm:px-4 hover:bg-gray-50 pt-6 pb-4 font-medium shadow-sm hover:shadow-md border border-gray-200 rounded-md transition duration-150 ease-in-out text-gray-700 hover:text-gray-900',
         {
           'animate-pulse': isLoading,
           'bg-gray-50 shadow-md': isActive
@@ -40,10 +40,10 @@ const GridCard = ({ connection, handleClick, isLoading, isActive = false }: IPro
           />
         </svg>
       ) : null}
-      <div className="w-full mx-auto">
+      <div className="w-full mx-auto overflow-hidden">
         <img className="w-12 h-12 mx-auto mb-3 rounded" src={icon} alt={name} />
-        <h4 className="text-base font-medium">{name}</h4>
-        <p className="text-sm font-medium text-gray-500 uppercase">{unifiedApi} API</p>
+        <h4 className="text-sm font-medium truncate sm:text-base">{name}</h4>
+        <p className="text-xs font-medium text-gray-500 uppercase sm:text-sm">{unifiedApi} API</p>
       </div>
     </div>
   )

--- a/src/components/Connection/GridCard.tsx
+++ b/src/components/Connection/GridCard.tsx
@@ -1,0 +1,52 @@
+import { IConnection } from 'types/Connection'
+import { MouseEventHandler } from 'react'
+import classNames from 'classnames'
+
+interface IProps {
+  connection: IConnection
+  delay: number
+  handleClick: MouseEventHandler<HTMLDivElement>
+  isLoading: boolean
+  isActive: boolean
+}
+
+const GridCard = ({ connection, handleClick, isLoading, isActive = false }: IProps) => {
+  const { name, icon, unified_api: unifiedApi } = connection
+
+  return (
+    <div
+      className={classNames(
+        'mx-auto cursor-pointer relative w-full px-4 hover:bg-gray-50 pt-6 pb-4 font-medium shadow-sm hover:shadow-md border border-gray-200 rounded-md transition duration-150 ease-in-out text-gray-700 hover:text-gray-900',
+        {
+          'animate-pulse': isLoading,
+          'bg-gray-50 shadow-md': isActive
+        }
+      )}
+      onClick={handleClick}
+    >
+      {isLoading ? (
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          className="absolute w-6 h-6 p-1 text-gray-500 bg-white border border-gray-300 rounded-full -top-3 -right-3 animate-spin"
+          fill="white"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="1.2"
+            d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+          />
+        </svg>
+      ) : null}
+      <div className="w-full mx-auto">
+        <img className="w-12 h-12 mx-auto mb-3 rounded" src={icon} alt={name} />
+        <h4 className="text-base font-medium">{name}</h4>
+        <p className="text-sm font-medium text-gray-500 uppercase">{unifiedApi} API</p>
+      </div>
+    </div>
+  )
+}
+
+export default GridCard

--- a/src/components/Connection/GridCard.tsx
+++ b/src/components/Connection/GridCard.tsx
@@ -1,6 +1,6 @@
-import { IConnection } from 'types/Connection'
-import { MouseEventHandler } from 'react'
 import classNames from 'classnames'
+import { MouseEventHandler } from 'react'
+import { IConnection } from 'types/Connection'
 
 interface IProps {
   connection: IConnection
@@ -16,10 +16,10 @@ const GridCard = ({ connection, handleClick, isLoading, isActive = false }: IPro
   return (
     <div
       className={classNames(
-        'mx-auto cursor-pointer relative w-full px-3 sm:px-4 hover:bg-gray-50 pt-6 pb-4 font-medium shadow-sm hover:shadow-md border border-gray-200 rounded-md transition duration-150 ease-in-out text-gray-700 hover:text-gray-900',
+        'mx-auto cursor-pointer relative w-full px-3 sm:px-4 pt-6 pb-4 font-medium hover:shadow-sm border border-gray-200 hover:border-blue-500 rounded-md transition duration-150 ease-in-out text-gray-700 hover:text-gray-900',
         {
           'animate-pulse': isLoading,
-          'bg-gray-50 shadow-md': isActive
+          'bg-gray-50 shadow-sm': isActive
         }
       )}
       onClick={handleClick}
@@ -43,7 +43,7 @@ const GridCard = ({ connection, handleClick, isLoading, isActive = false }: IPro
       <div className="w-full mx-auto overflow-hidden">
         <img className="w-12 h-12 mx-auto mb-3 rounded" src={icon} alt={name} />
         <h4 className="text-sm font-medium truncate sm:text-base">{name}</h4>
-        <p className="text-xs font-medium text-gray-500 uppercase sm:text-sm">{unifiedApi} API</p>
+        <p className="text-xs text-gray-500 mt-1 uppercase">{unifiedApi}</p>
       </div>
     </div>
   )

--- a/src/components/Connection/SearchedConnectionsList.tsx
+++ b/src/components/Connection/SearchedConnectionsList.tsx
@@ -1,0 +1,47 @@
+import { ConnectionCard } from 'components'
+import { IConnection } from 'types/Connection'
+import Link from 'next/link'
+import classNames from 'classnames'
+
+interface Props {
+  connections: IConnection[]
+  handleClick: (connection: IConnection, i: number) => void
+  cursor: number
+  isLoading: boolean | string
+}
+
+const SearchedConnectionsList = ({ connections, handleClick, cursor, isLoading }: Props) => {
+  return (
+    <div className="mt-6">
+      {connections?.map((connection: IConnection, i: number) => {
+        const { id, unified_api, service_id, state } = connection
+
+        if (state !== 'available') {
+          return (
+            <Link href={`/integrations/${unified_api}/${service_id}`} key={id}>
+              <a className={classNames('block', { 'mt-5': i !== 0 })}>
+                <ConnectionCard connection={connection} isActive={cursor === i} />
+              </a>
+            </Link>
+          )
+        } else {
+          return (
+            <button
+              onClick={() => handleClick(connection, i)}
+              key={id}
+              className={classNames('w-full', { 'mt-5': i !== 0 })}
+            >
+              <ConnectionCard
+                connection={connection}
+                isLoading={isLoading === connection.id}
+                isActive={cursor === i}
+              />
+            </button>
+          )
+        }
+      })}
+    </div>
+  )
+}
+
+export default SearchedConnectionsList

--- a/src/components/Inputs/SearchInput.tsx
+++ b/src/components/Inputs/SearchInput.tsx
@@ -1,0 +1,68 @@
+import { ChangeEvent, KeyboardEventHandler, RefObject, useEffect, useState } from 'react'
+
+import { TextInput } from '@apideck/components'
+
+const ACTION_KEY_DEFAULT = ['Ctrl ', 'Control']
+const ACTION_KEY_APPLE = ['⌘', 'Command']
+
+interface Props {
+  value: string
+  searchInputRef: RefObject<HTMLInputElement>
+  handleKeyDown: KeyboardEventHandler<HTMLInputElement>
+  onChange: (event: ChangeEvent<HTMLInputElement>) => void
+}
+
+const SearchInput = ({ value, searchInputRef, handleKeyDown, onChange }: Props) => {
+  const [browserDetected, setBrowserDetected] = useState(false)
+  const [actionKey, setActionKey] = useState(ACTION_KEY_DEFAULT)
+
+  useEffect(() => {
+    if (typeof navigator !== 'undefined') {
+      if (/(Mac|iPhone|iPod|iPad)/i.test(navigator.platform)) {
+        setActionKey(ACTION_KEY_APPLE)
+      } else {
+        setActionKey(ACTION_KEY_DEFAULT)
+      }
+      setBrowserDetected(true)
+    }
+  }, [])
+
+  return (
+    <div className="relative mt-6 lg:mt-8">
+      <div className="absolute left-0 flex items-center pt-2.5 md:pt-3 pl-3 pointer-events-none">
+        <svg
+          className="w-5 h-5 text-gray-400"
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 20 20"
+          fill="currentColor"
+          aria-hidden="true"
+        >
+          <path
+            fillRule="evenodd"
+            d="M8 4a4 4 0 100 8 4 4 0 000-8zM2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8z"
+            clipRule="evenodd"
+          />
+        </svg>
+      </div>
+      <TextInput
+        name="search"
+        type="text"
+        ref={searchInputRef}
+        placeholder="Search integrations"
+        value={value}
+        className="pl-10 md:py-2.5 lg:py-3 border-gray-50"
+        autoComplete="off"
+        onKeyDown={handleKeyDown}
+        onChange={onChange}
+      />
+      <span
+        style={{ opacity: browserDetected ? '1' : '0' }}
+        className="hidden whitespace-nowrap sm:block ml-2 md:ml-4 text-gray-400 text-sm py-0.5 px-1.5 border border-gray-300 rounded-md absolute right-2.5 top-2.5"
+      >
+        <span className="mr-1 font-medium">{actionKey[0]}</span>K
+      </span>
+    </div>
+  )
+}
+
+export default SearchInput

--- a/src/components/Modals/AddModal.tsx
+++ b/src/components/Modals/AddModal.tsx
@@ -1,5 +1,5 @@
 import { Button, useToast } from '@apideck/components'
-import { FormEventHandler, Fragment, useContext, useEffect, useRef, useState } from 'react'
+import { Fragment, useContext, useEffect, useRef, useState } from 'react'
 
 import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
 import { IConnection } from 'types/Connection'

--- a/src/components/shared/Layout.tsx
+++ b/src/components/shared/Layout.tsx
@@ -1,14 +1,15 @@
-import classNames from 'classnames'
-import { Transition } from 'components'
-import Head from 'next/head'
-import Link from 'next/link'
+import { HiChevronLeft, HiHome, HiOutlineDocumentText } from 'react-icons/hi'
 import Router, { useRouter } from 'next/router'
 import { useContext, useEffect, useState } from 'react'
+
 import { FiCompass } from 'react-icons/fi'
-import { HiChevronLeft, HiHome, HiOutlineDocumentText } from 'react-icons/hi'
+import Head from 'next/head'
+import Link from 'next/link'
+import SandboxBanner from './SandboxBanner'
 import { Theme } from 'types/JWTSession'
 import { ThemeContext } from 'utils/context'
-import SandboxBanner from './SandboxBanner'
+import { Transition } from 'components'
+import classNames from 'classnames'
 
 interface IProps {
   consumerMetadata: { [key: string]: string }
@@ -381,7 +382,7 @@ const Layout: React.FC<IProps> = ({
           )}
         >
           {sandboxMode ? <SandboxBanner /> : null}
-          <div className="flex flex-col max-w-4xl py-8 mx-4 sm:py-16 sm:mx-8 md:mx-12 lg:m-auto lg:py-32">
+          <div className="flex flex-col max-w-3xl py-8 mx-4 sm:py-16 sm:mx-8 md:m-auto lg:py-32">
             <Transition location={router.pathname}>{children}</Transition>
           </div>
         </main>

--- a/src/pages/api/_utils/headers.ts
+++ b/src/pages/api/_utils/headers.ts
@@ -1,6 +1,6 @@
 export const headers = {
   'Content-Type': 'application/json',
   Authorization: `Bearer ${process.env.NEXT_PUBLIC_UNIFY_API_KEY}`,
-  'X-APIDECK-CONSUMER-ID': `${process.env.NEXT_PUBLIC_UNIFY_CONSUMER_ID}123`,
+  'X-APIDECK-CONSUMER-ID': `${process.env.NEXT_PUBLIC_UNIFY_CONSUMER_ID}`,
   'X-APIDECK-APP-ID': `${process.env.NEXT_PUBLIC_UNIFY_APP_ID}`
 }

--- a/src/pages/api/_utils/headers.ts
+++ b/src/pages/api/_utils/headers.ts
@@ -1,6 +1,6 @@
 export const headers = {
   'Content-Type': 'application/json',
   Authorization: `Bearer ${process.env.NEXT_PUBLIC_UNIFY_API_KEY}`,
-  'X-APIDECK-CONSUMER-ID': `${process.env.NEXT_PUBLIC_UNIFY_CONSUMER_ID}`,
+  'X-APIDECK-CONSUMER-ID': `${process.env.NEXT_PUBLIC_UNIFY_CONSUMER_ID}123`,
   'X-APIDECK-APP-ID': `${process.env.NEXT_PUBLIC_UNIFY_APP_ID}`
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,11 +1,3 @@
-import { TextInput, useToast } from '@apideck/components'
-import classNames from 'classnames'
-import { ConnectionCard, ConnectionsList, ErrorBlock, ListPlaceholder } from 'components'
-import Fuse from 'fuse.js'
-import client from 'lib/axios'
-import { applySession } from 'next-session'
-import Link from 'next/link'
-import { useRouter } from 'next/router'
 import {
   ChangeEvent,
   KeyboardEvent,
@@ -15,17 +7,25 @@ import {
   useRef,
   useState
 } from 'react'
+import { ConnectionsList, ErrorBlock, ListPlaceholder } from 'components'
+
+import ConnectionsGrid from 'components/Connection/ConnectionsGrid'
+import Fuse from 'fuse.js'
 import { GlobalHotKeys } from 'react-hotkeys'
-import useSWR from 'swr'
 import { IConnection } from 'types/Connection'
 import { JWTSession } from 'types/JWTSession'
+import SearchInput from 'components/Inputs/SearchInput'
+import SearchedConnectionsList from 'components/Connection/SearchedConnectionsList'
 import { SessionExpiredModalContext } from 'utils/context'
+import { applySession } from 'next-session'
+import client from 'lib/axios'
 import { options } from 'utils/sessionOptions'
 import useDebounce from 'utils/useDebounce'
+import { useRouter } from 'next/router'
+import useSWR from 'swr'
+import { useToast } from '@apideck/components'
 
 const keyMap = { FOCUS_INPUT: ['command+k', 'control+k'] }
-const ACTION_KEY_DEFAULT = ['Ctrl ', 'Control']
-const ACTION_KEY_APPLE = ['⌘', 'Command']
 
 interface IProps {
   jwt: string
@@ -39,11 +39,9 @@ const Home = ({ jwt, token }: IProps): any => {
   const [cursor, setCursor] = useState(0)
   const debouncedSearchTerm = useDebounce(searchTerm, 250)
   const [isLoading, setIsLoading] = useState<boolean | string>(false)
-  const [browserDetected, setBrowserDetected] = useState(false)
-  const [actionKey, setActionKey] = useState(ACTION_KEY_DEFAULT)
   const { push } = useRouter()
   const { addToast } = useToast()
-  const ref: any = useRef()
+  const searchInputRef: any = useRef()
   let showSuggestions = false
   if (token.settings && 'showSuggestions' in token.settings) {
     showSuggestions = !!token.settings.showSuggestions
@@ -51,7 +49,7 @@ const Home = ({ jwt, token }: IProps): any => {
   const unifiedApis = token?.settings?.unifiedApis
 
   const focusInput = useCallback(() => {
-    ref?.current?.focus()
+    searchInputRef?.current?.focus()
   }, [])
 
   const handlers = { FOCUS_INPUT: focusInput }
@@ -86,8 +84,8 @@ const Home = ({ jwt, token }: IProps): any => {
   }, {})
   const addedConnections = connections?.filter((connection) => connection.state !== 'available')
   const isOnBoarded = process.browser && sessionStorage?.getItem('isOnBoarded')
-  const shouldOnBoard =
-    data && !error && !addedConnections?.length && !isOnBoarded && showSuggestions
+  const noAddedConnections = data && !error && !addedConnections?.length
+  const shouldOnBoard = noAddedConnections && !isOnBoarded && showSuggestions
 
   useEffect(() => {
     if (debouncedSearchTerm) {
@@ -104,17 +102,6 @@ const Home = ({ jwt, token }: IProps): any => {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [debouncedSearchTerm])
-
-  useEffect(() => {
-    if (typeof navigator !== 'undefined') {
-      if (/(Mac|iPhone|iPod|iPad)/i.test(navigator.platform)) {
-        setActionKey(ACTION_KEY_APPLE)
-      } else {
-        setActionKey(ACTION_KEY_DEFAULT)
-      }
-      setBrowserDetected(true)
-    }
-  }, [])
 
   useEffect(() => {
     if (shouldOnBoard) {
@@ -151,8 +138,8 @@ const Home = ({ jwt, token }: IProps): any => {
           }
         }
       )
-      mutate()
       successCallback()
+      mutate()
     } catch (error) {
       errorCallback()
 
@@ -175,14 +162,13 @@ const Home = ({ jwt, token }: IProps): any => {
     setIsLoading(connection.id)
 
     const successCallback = () => {
-      setIsLoading(false)
+      push(`/integrations/${connection.unified_api}/${connection.service_id}`)
       addToast({
         title: `Integration successfully added`,
         description: `You can now authorize it and manage integration settings.`,
         type: 'success',
         autoClose: true
       })
-      push(`/integrations/${connection.unified_api}/${connection.service_id}`)
     }
 
     const errorCallback = () => {
@@ -210,91 +196,47 @@ const Home = ({ jwt, token }: IProps): any => {
   return (
     <GlobalHotKeys handlers={handlers} keyMap={keyMap}>
       <h1 className="text-lg font-medium text-gray-800 md:text-2xl">Manage your integrations</h1>
-      {(!data && !error) || shouldOnBoard ? <ListPlaceholder /> : ''}
+      {(!data && !error) || shouldOnBoard ? <ListPlaceholder /> : null}
       {connections?.length && !shouldOnBoard ? (
         <>
-          <div className="relative mt-6 lg:mt-8">
-            <div className="absolute left-0 flex items-center pt-2.5 md:pt-3 pl-3 pointer-events-none">
-              <svg
-                className="w-5 h-5 text-gray-400"
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 20 20"
-                fill="currentColor"
-                aria-hidden="true"
-              >
-                <path
-                  fillRule="evenodd"
-                  d="M8 4a4 4 0 100 8 4 4 0 000-8zM2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8z"
-                  clipRule="evenodd"
-                />
-              </svg>
-            </div>
-            <TextInput
-              name="search"
-              type="text"
-              ref={ref}
-              placeholder="Search integrations"
-              value={searchTerm}
-              className="pl-10 md:py-2.5 lg:py-3 border-gray-50"
-              autoComplete="off"
-              onKeyDown={handleKeyDown}
-              onChange={(event: ChangeEvent<HTMLInputElement>) => setSearchTerm(event.target.value)}
+          <SearchInput
+            value={searchTerm}
+            handleKeyDown={handleKeyDown}
+            onChange={(event: ChangeEvent<HTMLInputElement>) => setSearchTerm(event.target.value)}
+            searchInputRef={searchInputRef}
+          />
+          {noAddedConnections ? (
+            <ConnectionsGrid
+              connections={list || connections}
+              handleClick={handleClick}
+              isLoading={isLoading}
+              cursor={!!searchTerm?.length && cursor}
             />
-            <span
-              style={{ opacity: browserDetected ? '1' : '0' }}
-              className="hidden whitespace-nowrap sm:block ml-2 md:ml-4 text-gray-400 text-sm py-0.5 px-1.5 border border-gray-300 rounded-md absolute right-2.5 top-2.5"
-            >
-              <span className="mr-1 font-medium">{actionKey[0]}</span>K
-            </span>
-          </div>
-          {searchTerm.length ? (
-            <div className="mt-6">
-              {list?.map((connection: IConnection, i) => {
-                const { id, unified_api, service_id, state } = connection
+          ) : null}
+          {!noAddedConnections && searchTerm.length ? (
+            <SearchedConnectionsList
+              connections={list}
+              isLoading={isLoading}
+              cursor={cursor}
+              handleClick={handleClick}
+            />
+          ) : null}
+          {!noAddedConnections && !searchTerm.length
+            ? Object.keys(connectionsPerUnifiedApiObj).map((unifiedApi) => {
+                const connections = connectionsPerUnifiedApiObj[unifiedApi]
 
-                if (state !== 'available') {
-                  return (
-                    <Link href={`/integrations/${unified_api}/${service_id}`} key={id}>
-                      <a className={classNames('block', { 'mt-5': i !== 0 })}>
-                        <ConnectionCard connection={connection} isActive={cursor === i} />
-                      </a>
-                    </Link>
-                  )
-                } else {
-                  return (
-                    <button
-                      onClick={() => handleClick(connection, i)}
-                      key={id}
-                      className={classNames('w-full', { 'mt-5': i !== 0 })}
-                    >
-                      <ConnectionCard
-                        connection={connection}
-                        isLoading={isLoading === connection.id}
-                        isActive={cursor === i}
-                      />
-                    </button>
-                  )
-                }
-              })}
-            </div>
-          ) : (
-            Object.keys(connectionsPerUnifiedApiObj).map((unifiedApi) => {
-              const connections = connectionsPerUnifiedApiObj[unifiedApi]
-
-              return (
-                <ConnectionsList
-                  key={unifiedApi}
-                  unifiedApi={unifiedApi}
-                  connections={connections}
-                  createConnection={createConnection}
-                />
-              )
-            })
-          )}
+                return (
+                  <ConnectionsList
+                    key={unifiedApi}
+                    unifiedApi={unifiedApi}
+                    connections={connections}
+                    createConnection={createConnection}
+                  />
+                )
+              })
+            : null}
         </>
-      ) : (
-        ''
-      )}
+      ) : null}
       {data && !connections?.length && <div className="mt-12">No integrations available.</div>}
     </GlobalHotKeys>
   )

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -92,7 +92,8 @@ const Home = ({ jwt, token }: IProps): any => {
   useEffect(() => {
     if (debouncedSearchTerm) {
       const fuse = new Fuse(connections, {
-        keys: ['name', 'unified_api']
+        keys: ['name', 'unified_api'],
+        threshold: 0.4
       })
       const results = fuse.search(debouncedSearchTerm)
       const connectionResults = results.map((result) => result.item)


### PR DESCRIPTION
@Gdewilde could you test ([with this link](https://integration-settings-git-f-connector-grid-view-apideck.vercel.app/session/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyZWRpcmVjdF91cmkiOiJodHRwOi8vbG9jYWxob3N0OjMwMDMvIiwiY29uc3VtZXJfbWV0YWRhdGEiOnsiYWNjb3VudF9uYW1lIjoidGVzdEBzYWxlc2ZvcmNlLmNvbSIsInVzZXJfbmFtZSI6IlRlc3QgVXNlciIsImltYWdlIjoiaHR0cHM6Ly91bmF2YXRhci5ub3cuc2gvamFrZSJ9LCJjb25zdW1lcl9pZCI6InRlc3QtY29uc3VtZXIxIiwiYXBwbGljYXRpb25faWQiOiJjZmFack9SZ2FIMlBNUXBJY2pUcGZoRVJJcElFVUpIZXYwOXVjalRwIiwic2NvcGVzIjpbXSwiaWF0IjoxNjM5NzQ0MTQyLCJleHAiOjE2Mzk3NDc3NDJ9.kdq6tPBMV-snJ8hwt5tqnpLQ56XYxTM_H8BnYv7SQlc)) to see if it's in line with what you had in mind? 

Might be a good idea to consider showing that grid view also after connections are added. We should then make some adjustments to those tiles and show the enabled status labels and group them by "added" - "not added", and per API.  Now it might be a bit confusing when navigating back and not being able to find those same tiles back. Also during the loading state, we can not show a correct skeleton loader because we only know after the call what layout we are going to use. Sometimes during redirecting the layout shifts which is a bit tricky to solve right now. 